### PR TITLE
fix: 自動更新有効でスクロールができなくなる問題を修正

### DIFF
--- a/content.js
+++ b/content.js
@@ -1125,7 +1125,9 @@ function run(settings){
                                     if(auto_reload_target_elem.getAttribute("auto_reload_mouse_hover") == "false"){
                                         if (column_content_reload){
                                             column_content_reload.Reload(auto_reload_target_elem.contentWindow);
-                                            (function f(){auto_reload_target_elem.contentWindow.scrollTo(0,0);requestAnimationFrame(f);})();
+                                            setTimeout(() => {
+                                                auto_reload_target_elem.contentWindow.scrollTo({ top: 0, behavior: 'auto' });
+                                            }, 100);
                                         }
                                     }
                                 };
@@ -1222,7 +1224,9 @@ function run(settings){
                                             if(auto_reload_target_object.getAttribute("auto_reload_mouse_hover") == "false"){
                                                 if (column_content_reload){
                                                     column_content_reload.Reload(auto_reload_target_object.contentWindow);
-                                                    (function f(){auto_reload_target_object.contentWindow.scrollTo(0,0);requestAnimationFrame(f);})();
+                                                    setTimeout(() => {
+                                                        auto_reload_target_object.contentWindow.scrollTo({ top: 0, behavior: 'auto' });
+                                                    }, 500);
                                                 }
                                             }
                                         };

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Open-Deck",
-  "version": "1.1.2.1",
+  "version": "1.1.2.2",
   "manifest_version": 3,
   "description": "The OpenSource Deck",
   "icons" : {

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,6 +1,6 @@
 {
     "name": "Open-Deck",
-    "version": "1.1.2.1",
+    "version": "1.1.2.2",
     "manifest_version": 2,
     "description": "The OpenSource Deck",
     "icons" : {


### PR DESCRIPTION
## 直したもの
- 自動更新
  - 自動更新有効でExploreカラムなどでスクロールができなくなる問題を修正

## マージ後の Open-Deck バージョン
- 1.1.2.2