### PR TITLE
fix: メディアビューワーが開かないことがある問題などを修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # checkout v6.0.2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # 一旦、履歴をすべて取得する
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # checkout v6.0.2
         with:
           fetch-depth: 0 # 一旦、履歴をすべて取得する
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2,6 +2,9 @@
   "app_console_welcome": {
     "message": "Welcome to Open-Deck!"
   },
+  "app_update": {
+    "message": "Open-Deck has been updated. View release notes?"
+  },
   "ui_profile_switch_title": {
     "message": "Switch profile"
   },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -2,6 +2,9 @@
   "app_console_welcome": {
     "message": "Open-Deckへようこそ！"
   },
+  "app_update": {
+    "message": "Open-Deckが更新されました！更新内容を確認しますか？"
+  },
   "ui_profile_switch_title": {
     "message": "プロファイルを切り替える"
   },

--- a/content.js
+++ b/content.js
@@ -157,6 +157,17 @@ if(location.href == "https://twitter.com/run-opdeck" || location.href == "https:
                             window.reload();
                         });
                     }
+
+                    //Updateされたときに設定のバージョンを上げる
+                    if(ext_update_flag){
+                        const setting = JSON.parse(value.opd_settings);
+                        setting.version = manifest.version;
+                        chrome.storage.local.set({'opd_settings': JSON.stringify(setting)}, function(){
+                            if(confirm(i18n_message("app_update"))){
+                                open(`https://github.com/kawa-nobu/Open-Deck/releases/tag/v${manifest.version}`, '_blank', 'popup');
+                            }
+                        });
+                    }
                     ext_settings = {column_settings:profile_store[last_load_profile].profile};
                 }else{
                     //ext_settings = JSON.parse(value.opd_settings);

--- a/content.js
+++ b/content.js
@@ -627,8 +627,7 @@ function run(settings){
 
     /* メディアビューワー */
     ::backdrop {
-        background: #474747;
-        opacity: 0.75;
+        background: rgba(0, 0, 0, 0.9);
     }
     #opd_media_viewer:focus {
         outline: none;
@@ -649,11 +648,14 @@ function run(settings){
     button[disabled].opd_media_viewer_func_btn{
         visibility: hidden;
     }
+    .opd_media_viewer_func_btn_icon_color{
+        filter: brightness(0) saturate(100%) invert(96%) sepia(6%) saturate(0%) hue-rotate(285deg) brightness(115%) contrast(100%);
+    }
     .opd_media_viewer_func_btn:hover{
-        background: #5555558a;
+        background: #2f2f2fa3;
     }
     .opd_media_viewer_func_btn_circle button:hover{
-        background: #5555558a;
+        background: #2f2f2fa3;
     }
     .media_viewer_icon_close{
         display: block;

--- a/content.js
+++ b/content.js
@@ -649,6 +649,15 @@ function run(settings){
         cursor: pointer;
         outline: none;
     }
+    .opd_media_viewer_func_btn.media_switch_btn{
+        width: 80px;
+        height: 80px;
+        margin: 10px;
+        border-radius: 10px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
     .opd_media_viewer_func_btn_circle button{
         border: 0;
         background: #00000000;
@@ -674,8 +683,8 @@ function run(settings){
         background-size: 20px;
         background-repeat: no-repeat;
         background-position: center;
-        width: 20px;
-        height: 20px;
+        width: 40px;
+        height: 40px;
         padding: 5px;
     }
     .media_viewer_icon_forward{

--- a/extensions/media_viewer/media_viewer.js
+++ b/extensions/media_viewer/media_viewer.js
@@ -74,7 +74,7 @@ class OpdExtMediaViewer {
 
             Object.assign(media_viewer_dialog, {
                 id: "opd_media_viewer",
-                style: "z-index:999999;border:none;background:none;padding:0;display:flex;flex-direction:column;align-items:center;gap:12px;width:80vw;height:80vh;overflow:hidden;"
+                style: "z-index:999999;border:none;background:none;padding:0;display:flex;flex-direction:column;align-items:center;gap:12px;width:85vw;height:85vh;overflow:hidden;"
             });
             media_viewer_dialog.closedBy = "any";
             media_viewer_dialog.innerHTML = `
@@ -116,6 +116,15 @@ class OpdExtMediaViewer {
 
             media_viewer_dialog.addEventListener("close", () => media_viewer_close());
             media_viewer_dialog.querySelector("[data-close]")?.addEventListener("click", () => media_viewer_close());
+
+            //背景クリックで閉じやすくする
+            media_viewer_dialog.addEventListener("click", (event)=>{
+                const tag_name = event.target.tagName;
+                const allowed_tag = ["IMG", "VIDEO", "SPAN", "BUTTON"];
+                if(!allowed_tag.includes(tag_name)){
+                    media_viewer_close();
+                }
+            })
 
 
             this.SkipBtnDisabled(media_viewer_dialog, media_info, current_media_idx);

--- a/extensions/media_viewer/media_viewer.js
+++ b/extensions/media_viewer/media_viewer.js
@@ -12,7 +12,7 @@ class OpdExtMediaViewer {
                 if (["animated_gif","video"].includes(info.type)) {
                     return `
                     <video data-media
-                        style="display:block;max-width:95vw;max-height:75vh;object-fit:contain;"
+                        style="width:auto;height:auto;max-width:calc(100% - 160px);max-height:100%;object-fit:contain;"
                         src="${info.video_info.variants.at(-1).url}"
                         controls
                         autoplay
@@ -23,7 +23,7 @@ class OpdExtMediaViewer {
                 if (info.type === "photo") {
                     return `
                         <img data-media
-                            style="display:block;max-width:95vw;max-height:75vh;object-fit:contain;"
+                            style="width:auto;height:auto;max-width:calc(100% - 160px);max-height:100%;object-fit:contain;"
                             src="${info.media_url_https + "?name=orig"}"
                         />`;
                 }
@@ -74,25 +74,23 @@ class OpdExtMediaViewer {
 
             Object.assign(media_viewer_dialog, {
                 id: "opd_media_viewer",
-                style: "z-index:999999;border:none;background:none;padding:0;" +
-                "display:flex;flex-direction:column;align-items:center;gap:12px;" +
-                "max-width:95vw;max-height:95vh;"
+                style: "z-index:999999;border:none;background:none;padding:0;display:flex;flex-direction:column;align-items:center;gap:12px;width:80vw;height:80vh;overflow:hidden;"
             });
             media_viewer_dialog.closedBy = "any";
             media_viewer_dialog.innerHTML = `
-            <div style="width:100%;height:100%;">
+            <div style="width:100%;height:100%;display:flex;flex-direction:column;overflow:hidden;align-items:center;">
                 <div class="opd_media_viewer_func_btn_circle" style="display:flex;width:100%;justify-content:flex-end;">
-                    <button type="button" data-close><span class="media_viewer_icon_close opd_ui_icon_color"></span></button>
+                    <button type="button" data-close><span class="media_viewer_icon_close opd_media_viewer_func_btn_icon_color"></span></button>
                 </div>
 
-                <div style="display: flex;flex-direction: row;">
-                    <button type="button" class="opd_media_viewer_func_btn" style="width: 80px;border-radius: 10px 0 0 10px;" data-media-forward><span class="media_viewer_icon_forward opd_ui_icon_color"></span></button>
+                <div style="display:flex;flex-direction:row;flex:1;min-height:0;overflow:hidden;align-items:center;width:fit-content;">
+                    <button type="button" class="opd_media_viewer_func_btn" style="width:80px;border-radius:10px 0 0 10px;" data-media-forward><span class="media_viewer_icon_forward opd_media_viewer_func_btn_icon_color"></span></button>
                     ${mediaHTMLAt(current_media_idx)}
-                    <button type="button" class="opd_media_viewer_func_btn" style="width: 80px;border-radius: 0 10px 10px 0;" data-media-next><span class="media_viewer_icon_next opd_ui_icon_color"></span></button>
+                    <button type="button" class="opd_media_viewer_func_btn" style="width:80px;border-radius:0 10px 10px 0;" data-media-next><span class="media_viewer_icon_next opd_media_viewer_func_btn_icon_color"></span></button>
                 </div>
 
                 <div class="opd_media_viewer_func_btn_circle" style="width:100%;display:flex;justify-content:center;">
-                    <button type="button" data-media-download><span class="media_viewer_icon_download opd_ui_icon_color"></span></button>
+                    <button type="button" data-media-download><span class="media_viewer_icon_download opd_media_viewer_func_btn_icon_color"></span></button>
                 </div>
             </div>
             `;

--- a/extensions/media_viewer/media_viewer.js
+++ b/extensions/media_viewer/media_viewer.js
@@ -84,12 +84,12 @@ class OpdExtMediaViewer {
                 </div>
 
                 <div style="display:flex;flex-direction:row;flex:1;min-height:0;overflow:hidden;align-items:center;width:fit-content;">
-                    <button type="button" class="opd_media_viewer_func_btn" style="width:80px;border-radius:10px 0 0 10px;" data-media-forward><span class="media_viewer_icon_forward opd_media_viewer_func_btn_icon_color"></span></button>
+                    <button type="button" class="opd_media_viewer_func_btn media_switch_btn" data-media-forward><span class="media_viewer_icon_forward opd_media_viewer_func_btn_icon_color"></span></button>
                     ${mediaHTMLAt(current_media_idx)}
-                    <button type="button" class="opd_media_viewer_func_btn" style="width:80px;border-radius:0 10px 10px 0;" data-media-next><span class="media_viewer_icon_next opd_media_viewer_func_btn_icon_color"></span></button>
+                    <button type="button" class="opd_media_viewer_func_btn media_switch_btn" data-media-next><span class="media_viewer_icon_next opd_media_viewer_func_btn_icon_color"></span></button>
                 </div>
 
-                <div class="opd_media_viewer_func_btn_circle" style="width:100%;display:flex;justify-content:center;">
+                <div class="opd_media_viewer_func_btn_circle" style="width:100%;margin-top:10px;display:flex;justify-content:center;">
                     <button type="button" data-media-download><span class="media_viewer_icon_download opd_media_viewer_func_btn_icon_color"></span></button>
                 </div>
             </div>

--- a/extensions/media_viewer_block.js
+++ b/extensions/media_viewer_block.js
@@ -14,6 +14,26 @@ class OpdMediaViewerBlocker {
                     composed: true,
                     detail: JSON.stringify({ token: this.opd_send_media_info_token })
                 }));
+
+                /*ショートカットキーとしてAlt(Option)キーの動作を設定*/
+                document.addEventListener('keydown', (event) => {
+                    if(event.key === 'Alt'){
+                        column_window.document.dispatchEvent(new CustomEvent('opd_media_viewer_shotcut', {
+                            bubbles: true,
+                            composed: true,
+                            detail: JSON.stringify({token: this.opd_send_media_info_token, keys:{alt:true}})
+                        }));
+                    }
+                });
+                document.addEventListener('keyup', (event) => {
+                    if(event.key === 'Alt'){
+                        column_window.document.dispatchEvent(new CustomEvent('opd_media_viewer_shotcut', {
+                            bubbles: true,
+                            composed: true,
+                            detail: JSON.stringify({token: this.opd_send_media_info_token, keys:{alt:false}})
+                        }));
+                    }
+                });
             });
 
             column_window.document.head.appendChild(helper_script);

--- a/extensions/media_viewer_block.js
+++ b/extensions/media_viewer_block.js
@@ -6,14 +6,17 @@ class OpdMediaViewerBlocker {
             //ヘルパースクリプト追加
             const helper_script = column_window.document.createElement('script');
             helper_script.src = chrome.runtime.getURL("extensions/media_viewer_block_helper.js");
-            column_window.document.head.appendChild(helper_script);
 
             this.opd_send_media_info_token = crypto.randomUUID();
-            setTimeout(() => {
+            helper_script.addEventListener('load', () => {
                 column_window.document.dispatchEvent(new CustomEvent('opd_send_media_info_init', {
-                    detail: JSON.stringify({ token:this.opd_send_media_info_token })
+                    bubbles: true,
+                    composed: true,
+                    detail: JSON.stringify({ token: this.opd_send_media_info_token })
                 }));
-            }, 500);
+            });
+
+            column_window.document.head.appendChild(helper_script);
         }
     }
 }

--- a/extensions/media_viewer_block_helper.js
+++ b/extensions/media_viewer_block_helper.js
@@ -93,7 +93,7 @@
         return propsKey ? elem[propsKey] : null;
     }
     //機能動作用のトークンを設定
-    window.addEventListener('opd_send_media_info_init', (e)=>{
+    document.addEventListener('opd_send_media_info_init', (e)=>{
         const detail = JSON.parse(e.detail);
         opd_send_media_info_token = detail.token;
     }, true);

--- a/extensions/media_viewer_block_helper.js
+++ b/extensions/media_viewer_block_helper.js
@@ -1,12 +1,16 @@
 //メディアビューワー停止用
 (() => {
     let opd_send_media_info_token = null;
+    let is_alt_pressed = false;
     //カラム側の画像表示を停止させて、表示画像などの情報をOPD側に渡す
     /*
     TODO:ツイートページのツイートに画像や動画付きの引用が付いていて、引用のメディアをクリックした際に元のメディアが表示される問題を修正する。
     ※引用を開いた際の判定と引用のメディア情報を抽出する方法を調査する
     */
     document.addEventListener("click", (e) => {
+        //Alt(Option)キーが押されている場合はメディアビューワーを使用しないようにする
+        if(is_alt_pressed) return;
+
         //引用の場合に格納される
         const quoted = e.target.closest('div[tabindex="0"][role="link"]');
         // 通常のメディア付きツイート
@@ -97,4 +101,22 @@
         const detail = JSON.parse(e.detail);
         opd_send_media_info_token = detail.token;
     }, true);
+    /*ショートカットキーとしてAlt(Option)キーの動作を設定*/
+    document.addEventListener('opd_media_viewer_shotcut', (e)=>{
+        //カラムが非アクティブの場合
+        const detail = JSON.parse(e.detail);
+
+        if(detail.token !== opd_send_media_info_token) return;
+
+        is_alt_pressed = detail.keys.alt;
+    }, true);
+    //カラムがアクティブの場合
+    document.addEventListener('keydown', (event) => {
+        console.log("shift_down")
+        if (event.key === 'Alt') is_alt_pressed = true;
+    });
+    document.addEventListener('keyup', (event) => {
+        console.log("shift_up")
+        if (event.key === 'Alt') is_alt_pressed = false;
+    });
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Open-Deck",
-  "version": "1.1.3.1",
+  "version": "1.1.3.2",
   "manifest_version": 3,
   "description": "The OpenSource Deck",
   "default_locale": "ja",

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,6 +1,6 @@
 {
     "name": "Open-Deck",
-    "version": "1.1.3.1",
+    "version": "1.1.3.2",
     "manifest_version": 2,
     "description": "The OpenSource Deck",
     "default_locale": "ja",


### PR DESCRIPTION
## 追加されたもの / New features
- お試し実装
  - Alt(Option)キーを押しながら画像や動画をクリックした際にメディアビューワーを開かないようにした
    - Open-Deck側のメディアビューワーを使用せずに従来の表示方法が必要な場合に利用する想定
    - Firefox や 一部カラムでは動作しないことがある
    - ※将来的に削除される可能性があります

## 直したもの / Fixed items
- メディアビューワー
  - ビューワーが開かないことがある問題を修正
  - 背景などをクリックした際にビューワーが閉じやすくなるように修正
  - ビューワーのアイコン類や表示の使い勝手を改善


## 動作確認 / Verification

- [x] Firefox系のブラウザでも問題なく動作するか (お試し実装は除く)
  - 検証したバージョン
    - 148.0 (aarch64)

## その他の変更 / Other Changes
- バージョン更新時にアップデート通知を行い、リリースノートを見れるようにした

- GitHub Actionsのcheckoutのバージョンを`6.0.2`に上げた


## マージ後の Open-Deck バージョン / Open-Deck version after merging
- `1.1.3.2`

## 雑記(あればご自由にどうぞ) / Personal Notes (Optional / Feel free to write anything!)
お試し実装でショートカットキーを使って、
メディアビューワーを使用せずに従来の画面で開けるようにしてみました！
ブラウザやカラムによって動作しないことや、将来的に削除される機能かもしれないので、
その点を念頭に置いてもらえると嬉しいです！

- 作業中に聴いていた楽曲 (覚えている限り)
  - 風の辿り着く場所 (彩菜)
    - https://www.youtube.com/watch?v=4y2n_fOUNJA
    - 間奏の謎ラップの正体が分かったのでスッキリしました
