### PR TITLE
fix: 起動時カラムが呼び出せない問題と自動更新周りの挙動

### DIFF
--- a/about_opd.html
+++ b/about_opd.html
@@ -80,6 +80,7 @@
         <div>Development<br><a href="https://twitter.com/kw_nobu2" target="_blank" rel="noopener noreferrer">kawa-nobu</a></div>
         <div>GitHub<br><a href="https://github.com/kawa-nobu/Open-Deck" target="_blank" rel="noopener noreferrer">Open-Deck</a></div>
         <div>ChangeLog<br><a href="https://github.com/kawa-nobu/Open-Deck/releases" target="_blank" rel="noopener noreferrer">Releases</a></div>
+        <div>Help<br><a href="https://kawa-nobu.github.io/Open-Deck-Wiki/" target="_blank" rel="noopener noreferrer">Open-Deck Document</a></div>
     </section>
 </body>
 </html>

--- a/background.js
+++ b/background.js
@@ -2,14 +2,24 @@ const EXTENSION_DOMAIN = new URL(chrome.runtime.getURL('')).hostname;
 
 //インストール時にあらかじめDNRを設定しておく
 chrome.runtime.onInstalled.addListener(() => {
-    update_dnr();
+    (async () => {
+        await update_dnr();
+    })();
 })
 
 chrome.runtime.onMessage.addListener(
     function(request, sender, sendResponse){
         if(request.message == "dnr_upd"){
-            update_dnr();
-            sendResponse(true);
+            (async () => {
+                try {
+                    await update_dnr();
+                    console.log("dnr_update_ok");
+                    sendResponse(true);
+                } catch(e) {
+                    console.error("dnr update failed->", e);
+                    sendResponse(false);
+                }
+            })();
         }
         if(request.message == "text_review"){
             const api_url = "https://opd.kwdev-sys.com/api/opd/text_review/review";
@@ -24,11 +34,13 @@ chrome.runtime.onMessage.addListener(
                     if(!res.ok){
                         console.error(`ReviewFetchError->Code:${res.status}->Text:${res.statusText}`);
                         sendResponse(false);
+                        return;
                     }
                     sendResponse(await res.json());
                 }catch(error){
                     console.error("Fetch failed:", error);
                     sendResponse(false);
+                    return;
                 }
             })();
         }
@@ -155,10 +167,9 @@ function update_dnr(){
             }
         },
     ];
-    chrome.declarativeNetRequest.updateDynamicRules({
+    
+    return chrome.declarativeNetRequest.updateDynamicRules({
         removeRuleIds: [1],
         addRules: dnr_rules,
-    }, function(){
-        console.log("dnr_update_ok");
     });
 }

--- a/background.js
+++ b/background.js
@@ -1,50 +1,15 @@
+const EXTENSION_DOMAIN = new URL(chrome.runtime.getURL('')).hostname;
+
+//インストール時にあらかじめDNRを設定しておく
+chrome.runtime.onInstalled.addListener(() => {
+    update_dnr();
+})
+
 chrome.runtime.onMessage.addListener(
     function(request, sender, sendResponse){
         if(request.message == "dnr_upd"){
-            /*chrome.declarativeNetRequest.updateEnabledRulesets(({disableRulesetIds: ["ruleset_1"]}));
-            chrome.declarativeNetRequest.updateEnabledRulesets(({enableRulesetIds: ["ruleset_1"]}));*/
-            const dnr_rules = [
-                {
-                    id : 1,
-                    priority: 1,
-                    action: {
-                        type: "modifyHeaders",
-                        responseHeaders: [
-                            {
-                                header: "Content-Security-Policy",
-                                operation: "remove"
-                            },
-                            {
-                                header: "X-Frame-Options",
-                                operation: "remove"
-                            }
-                        ]
-                    },
-                    condition : {
-                        urlFilter : "x.com",
-                        resourceTypes: ["main_frame",
-                        "sub_frame",
-                        "stylesheet",
-                        "script",
-                        "image",
-                        "font",
-                        "object",
-                        "xmlhttprequest",
-                        "ping",
-                        "csp_report",
-                        "media",
-                        "websocket",
-                        "other"]
-                    }
-                }
-            ];
-            chrome.declarativeNetRequest.updateSessionRules({//updateDynamicRules
-                removeRuleIds: [1],
-                addRules: dnr_rules,
-            }, function(){
-                console.log("dnr_update_ok");
-                sendResponse(true);
-            });
+            update_dnr();
+            sendResponse(true);
         }
         if(request.message == "text_review"){
             const api_url = "https://opd.kwdev-sys.com/api/opd/text_review/review";
@@ -152,4 +117,48 @@ chrome.webRequest.onHeadersReceived.addListener(function (resp) {
       }
     },{urls: ['*://x.com/i/api/*']},['responseHeaders']
   );
-//
+
+function update_dnr(){
+    const dnr_rules = [
+        {
+            id : 1,
+            priority: 1,
+            action: {
+                type: "modifyHeaders",
+                responseHeaders: [
+                    {
+                        header: "Content-Security-Policy",
+                        operation: "remove"
+                    },
+                    {
+                        header: "X-Frame-Options",
+                        operation: "remove"
+                    }
+                ]
+            },
+            condition : {
+                requestDomains: ["x.com", "twitter.com"],
+                initiatorDomains: [EXTENSION_DOMAIN, "x.com", "twitter.com"],
+                resourceTypes: ["main_frame",
+                "sub_frame",
+                "stylesheet",
+                "script",
+                "image",
+                "font",
+                "object",
+                "xmlhttprequest",
+                "ping",
+                "csp_report",
+                "media",
+                "websocket",
+                "other"]
+            }
+        },
+    ];
+    chrome.declarativeNetRequest.updateDynamicRules({
+        removeRuleIds: [1],
+        addRules: dnr_rules,
+    }, function(){
+        console.log("dnr_update_ok");
+    });
+}

--- a/content.js
+++ b/content.js
@@ -204,7 +204,8 @@ function run(settings){
     //console.log(profile_list_btn_html)
     //カラム全体のテキストフォーカスの状態で自動更新を制御できるようにする
     window.addEventListener('opd_post_focus', (e) => {
-        if(e.detail){
+        const detail = JSON.parse(e.detail);
+        if(detail){
             column_auto_update_state.text_focus.date = Date.now();
             column_auto_update_state.text_focus.active = true;
         }else{

--- a/content.js
+++ b/content.js
@@ -931,6 +931,10 @@ function run(settings){
         }else{
             column_object = document.querySelectorAll('.dsp_column:not([opd_column_type="dsp_column"], [opd_column_type="empty_column"], [opd_column_type="main_bar_empty_column"]) iframe');
         }
+
+        //カラム読み込み失敗検出
+        watch_load_column(column_object);
+
         for (let index = 0; index < column_object.length; index++) {
             column_object[index].removeAttribute("opd_init_webview");
             //バナー/表示モード変更
@@ -1862,6 +1866,35 @@ function get_cookie_color_mode() {
 
     //カラーモードが 1 以上の場合は dark を返す
     return "dark";
+}
+//カラム読み込み失敗検出
+function watch_load_column(column_frames, max_retries = 5){
+    const cleanups = [];
+    column_frames.forEach(column => {
+        let count = 0;
+
+        const reLoad = () => {
+            if (++count >= max_retries) return;
+            setTimeout(() => { column.src = column.src }, 500);
+        };
+
+        const onLoad = () => {
+            try {
+                column.contentWindow.document.querySelector('head');
+            } catch {
+                reLoad();
+            }
+        };
+
+        column.addEventListener('load', onLoad);
+        column.addEventListener('error', reLoad);
+        cleanups.push(() => {
+            column.removeEventListener('load', onLoad);
+            column.removeEventListener('error', reLoad);
+        });
+    });
+
+    setTimeout(() => cleanups.forEach(fn => fn()), max_retries * 500 + 1000);
 }
 //設定初期化
 function settings_init(){

--- a/content.js
+++ b/content.js
@@ -1004,14 +1004,6 @@ function run(settings){
                             break;
                     }
                     //console.log(opd_column_div.querySelector(".opd_banner").checked)
-                    //ポストカラムの動作
-                    if(this.closest("div[opd_column_type]").getAttribute("opd_column_type") === "post"){
-                        const post_column_window = opd_column_div.querySelector("iframe").contentWindow;
-                        //文章校正機能
-                        const ext_text_review = new OpdExtTextReview();
-                        const ui_lang = chrome.i18n.getUILanguage();
-                        ext_text_review.Init(post_column_window, ui_icon_define, ui_lang);
-                    }
                 }
             })
             //各カラム読み込み後の動作(init)
@@ -1027,21 +1019,12 @@ function run(settings){
                 let opd_column_auto_reload_time_reload = opd_column_div.querySelector(".opd_a_reload_time_setting");
                 let opd_column_tw_view_mode_opt = opd_column_div.querySelector(".opd_tw_view_mode");
                 let opd_column_scroll_to_top = opd_column_div.querySelector(".opd_column_scroll_to_top");
-                let column_content_reload = null;
+
                 //カラム拡張読み込み
                 if(mode != "session_set"){
-                    const column_type = this.closest("div[opd_column_type]").getAttribute("opd_column_type");
-                    if(column_type === "home" || column_type === "explore"){
-                        const target_column = this.closest("div[opd_column_type]").querySelector("iframe").contentWindow;
-                        //自動更新関連仕込み
-                        column_content_reload = new OpdExtAutoReload();
-                        column_content_reload.Init(target_column);
-                        //メディアビューワー関連仕込み
-                        const column_media_viewer_blocker = new OpdMediaViewerBlocker();
-                        column_media_viewer_blocker.Init(target_column);
-                        media_viewer_token.push(column_media_viewer_blocker.opd_send_media_info_token);
-                    }
+                    reinit_column_extensions(this.closest("div[opd_column_type]"));
                 }
+
                 //設定パネルイベント
                 if(mode != "session_set"){
                     opd_column_div.querySelector(".opd_settings_btn").addEventListener("click", function(){
@@ -1238,8 +1221,8 @@ function run(settings){
                                 const path_name = auto_reload_target_elem.contentWindow.location.pathname;
                                 if(['/home', '/search'].includes(path_name) || path_name.startsWith('/i/lists')){
                                     if(auto_reload_target_elem.getAttribute("auto_reload_mouse_hover") == "false"){
-                                        if (column_content_reload){
-                                            column_content_reload.Reload(auto_reload_target_elem.contentWindow);
+                                        if (auto_reload_target_elem.opd_auto_reload){
+                                            auto_reload_target_elem.opd_auto_reload.Reload(auto_reload_target_elem.contentWindow);
                                             setTimeout(() => {
                                                 auto_reload_target_elem.contentWindow.scrollTo({ top: 0, behavior: 'auto' });
                                             }, 100);
@@ -1337,8 +1320,8 @@ function run(settings){
                                         const path_name = auto_reload_target_object.contentWindow.location.pathname;
                                         if(['/home', '/search'].includes(path_name) || path_name.startsWith('/i/lists')){
                                             if(auto_reload_target_object.getAttribute("auto_reload_mouse_hover") == "false"){
-                                                if (column_content_reload){
-                                                    column_content_reload.Reload(auto_reload_target_object.contentWindow);
+                                                if (auto_reload_target_object.opd_auto_reload){
+                                                    auto_reload_target_object.opd_auto_reload.Reload(auto_reload_target_object.contentWindow);
                                                     setTimeout(() => {
                                                         auto_reload_target_object.contentWindow.scrollTo({ top: 0, behavior: 'auto' });
                                                     }, 500);
@@ -1612,6 +1595,49 @@ function run(settings){
             alert(i18n_message("msg_profile_delete_current_alert"));
         }
     });
+    //カラム拡張機能の初期化
+    function reinit_column_extensions(column_div){
+        const column_frame = column_div?.querySelector("iframe");
+        if(!column_frame) return;
+        const column_type = column_div.getAttribute("opd_column_type");
+
+        let initialized = false;
+        const doInit = () => {
+            if(initialized) return;
+            const target_window = column_frame.contentWindow;
+
+            if(target_window && (!target_window.document || !target_window.document.head)) return;
+            initialized = true;
+
+            //ユーティリティ仕込み
+            const opd_utils = new OpdUtils();
+            opd_utils.Init(target_window);
+
+            //文章校正機能を組み込む
+            if(column_type === "post"){
+                const ext_text_review = new OpdExtTextReview();
+                const ui_lang = chrome.i18n.getUILanguage();
+                ext_text_review.Init(target_window, ui_icon_define, ui_lang);
+            }
+
+            //自動更新とメディアビューワーを仕込む
+            if(column_type === "home" || column_type === "explore"){
+                const auto_reload = new OpdExtAutoReload();
+                auto_reload.Init(target_window);
+                //カラムフレームに紐付けて、自動更新部分で参照できるようにする
+                column_frame.opd_auto_reload = auto_reload;
+
+                const blocker = new OpdMediaViewerBlocker();
+                blocker.Init(target_window);
+                media_viewer_token.push(blocker.opd_send_media_info_token);
+            }
+        };
+
+        column_frame.addEventListener("load", doInit, { once: true });
+
+        //loadが発火しない場合にフォールバックする
+        setTimeout(doInit, 500);
+    }
     //カラム移動
     function column_dd(){
         let column_class = document.querySelectorAll(".dsp_column");
@@ -1655,6 +1681,9 @@ function run(settings){
                     this.style.borderLeft = '';
                     //append_object_css();
                     //column_dd();
+
+                    reinit_column_extensions(dr_elem.querySelector("div[opd_column_type]"));
+
                     column_settings_save("", last_load_profile);
                 }else{
                     this.style.borderLeft = '';

--- a/content.js
+++ b/content.js
@@ -748,7 +748,7 @@ function run(settings){
     let default_element = {
         /*main_bar_empty_column:{html:`<!--<section draggable="false" class="dsp_column"><div opd_column_type="main_bar_empty_column" opd_column_width="%column_width_num%" id="main_bar_empty_column" style="height:100%;min-width: 70px;"></div></section>-->`},*/
         empty_column:{html:`<section draggable="false" id="column_%column_num%" class="dsp_column_draggable_false dsp_column dsp_column_emptycolumn"><div opd_column_type="empty_column" opd_column_width="%column_width_num%" style="height: 100%;min-width: 30rem;display: flex;align-items: center;justify-content: center;"><div><img src="${chrome.runtime.getURL(ui_icon_define.column_add_1)}" style="filter: brightness(0) saturate(100%) invert(61%) sepia(13%) saturate(13%) hue-rotate(335deg) brightness(89%) contrast(79%);"><p>左のバーからカラムを追加</p></div></div></section>`},
-        post:{html:`<section draggable="true" id="column_%column_num%" class="dsp_column_draggable_true dsp_column"><div opd_column_type="post" opd_column_width="%column_width_num%" style="height: 100%;width: %column_width_num%rem;min-width: 1rem;"><div class="column_bar" style="height: max-content;"><span class="dsp_column_title"><div class="dsp_column_move_icon_parent"><span class="dsp_column_move_icon"></span><span>Post</span></div></span>${post_element_bar}<div class="dsp_column_empty_area opd_column_scroll_to_top"></div><div class="dsp_column_close_btn_wrap"><span class="dsp_column_btn"><label class="dsp_column_close_btn opd_ui_icon_color" title="カラムを閉じる"><input type="button" class="column_close_btn" value="X"/></label></span></div></div>${column_settings_panel_no_auto}<iframe auto_reload_mouse_hover="false" allow="fullscreen" src="https://x.com/compose/post" type="text/html" style="width: 100%;height: 100%;" opd_init_webview></iframe></div></section>`},
+        post:{html:`<section draggable="true" id="column_%column_num%" class="dsp_column_draggable_true dsp_column"><div opd_column_type="post" opd_column_width="%column_width_num%" style="height: 100%;width: %column_width_num%rem;min-width: 1rem;"><div class="column_bar" style="height: max-content;"><span class="dsp_column_title"><div class="dsp_column_move_icon_parent"><span class="dsp_column_move_icon"></span><span>Post</span></div></span>${post_element_bar}<div class="dsp_column_empty_area opd_column_scroll_to_top"></div><div class="dsp_column_close_btn_wrap"><span class="dsp_column_btn"><label class="dsp_column_close_btn opd_ui_icon_color" title="カラムを閉じる"><input type="button" class="column_close_btn" value="X"/></label></span></div></div>${column_settings_panel_no_auto}<iframe auto_reload_mouse_hover="false" allow="fullscreen" src="https://x.com/intent/tweet" type="text/html" style="width: 100%;height: 100%;" opd_init_webview></iframe></div></section>`},
         second_empty_column:{html:`<section draggable="false" id="column_%column_num%" class="dsp_column_draggable_false dsp_column dsp_column_second_emptycolumn"><div opd_column_type="second_empty_column" opd_column_width="%column_width_num%" style="height:100%;min-width: 30rem;overflow: hidden;display: flex;align-items: center;justify-content: center;"><div><img src="${chrome.runtime.getURL(ui_icon_define.column_add_2)}" style="filter: brightness(0) saturate(100%) invert(61%) sepia(13%) saturate(13%) hue-rotate(335deg) brightness(89%) contrast(79%);"><p>1段目のカラムが配置できます</p></div></div></section>`},
         home:{html:`<section draggable="true" id="column_%column_num%" class="dsp_column_draggable_true dsp_column"><div opd_column_type="home" opd_column_width="%column_width_num%" style="height: 100%;width: %column_width_num%rem;min-width: 1rem;"><div class="column_bar" style="height: max-content;"><span class="dsp_column_title"><div class="dsp_column_move_icon_parent"><span class="dsp_column_move_icon"></span><span>Timeline</span></div></span>${default_element_bar}<div class="dsp_column_empty_area opd_column_scroll_to_top"></div><div class="dsp_column_close_btn_wrap"><span class="dsp_column_btn"><label class="dsp_column_close_btn opd_ui_icon_color" title="カラムを閉じる"><input type="button" class="column_close_btn" value="X"/></label></span></div></div>${column_settings_panel}<iframe auto_reload_mouse_hover="false" allow="fullscreen" src="https://x.com/home" type="text/html" style="width: 100%;height: 100%;" opd_init_webview></iframe></div></section>`},
         notification:{html:`<section draggable="true" id="column_%column_num%" class="dsp_column_draggable_true dsp_column"><div opd_column_type="notification" opd_column_width="%column_width_num%" style="height: 100%;width: %column_width_num%rem;min-width: 1rem;"><div class="column_bar" style="height: max-content;"><span class="dsp_column_title"><div class="dsp_column_move_icon_parent"><span class="dsp_column_move_icon"></span><span>Notifications</span></div></span>${default_element_bar}<div class="dsp_column_empty_area opd_column_scroll_to_top"></div><div class="dsp_column_close_btn_wrap"><span class="dsp_column_btn"><label class="dsp_column_close_btn opd_ui_icon_color" title="カラムを閉じる"><input type="button" class="column_close_btn" value="X"/></label></span></div></div>${column_settings_panel_no_auto}<iframe allow="fullscreen" src="https://x.com/notifications" type="text/html" style="width: 100%;height: 100%;" opd_init_webview></iframe></div></section>`},
@@ -837,6 +837,25 @@ function run(settings){
     ins_html.innerHTML = `${side_bar}<div id="main_rack_element" style=""><div id="first_rack_element" style="height: 100%;display:flex;flex-direction:row;">${main_column_html}</div><div id="second_rack_element" style="display:flex;flex-direction:row;">${second_column_html}</div></div>`;
     //HTML挿入
     document.body.insertAdjacentElement("afterbegin", ins_html);
+
+    //favicon・タイトルを設定
+    set_title_favicon()
+
+    //react-rootを監視しマスク処理をする
+    observe_when_ready(
+        () => document.getElementById("react-root"),
+        document.body,
+        main_dsp,
+        { childList: true, characterData: true, subtree: false }
+    );
+
+    //headを監視しカラーモード機能やCSSを設定・変更する
+    observe_when_ready(
+        () => document.querySelector("head"),
+        document.documentElement,
+        head_observer_callback,
+        { childList: true, subtree: false }
+    );
     //APIリミット表示用
     document.querySelector("#api_limit_status").addEventListener("click", function(){
         if(api_limit_obj != null){
@@ -1669,7 +1688,7 @@ function run(settings){
         let column_class = document.querySelectorAll(".dsp_column");
         let column_copy_source = null;
         for (let index = 0; index < column_class.length; index++) {
-            //既にD&Dが登録済みのカラムはスキップ
+            //既にイベントが登録済みのカラムはスキップ
             if(column_class[index].dataset.opd_dd_initialized === "1") continue;
             column_class[index].dataset.opd_dd_initialized = "1";
         
@@ -1851,83 +1870,170 @@ function run(settings){
     function create_random_id(){
         return Math.random().toString(32).substring(2);
     }
-    //メインX動作マスク
-    function main_dsp(){
-        document.getElementById("react-root").style.visibility = "hidden";
-        document.getElementById("react-root").style.overflow = "hidden";
-    }
-    const target_elem = document.getElementById("react-root");
-    const observer = new MutationObserver(main_dsp);
-    observer.observe(target_elem,{
-        childList: true,
-        characterData: true,
-        subtree: false
-    });
-    //title変更監視
-    const head_observer = new MutationObserver(function(){
-        document.title = "Open-Deck";
-        document.querySelector('link[rel="shortcut icon"]').href = chrome.runtime.getURL("icon.png");
-        //デフォルトのCSSがUIに影響を与えないように削除する
-        if(!is_removed_default_style){
-            document.head.querySelectorAll('style').forEach(style => {
-                if(style.textContent.includes('*, ::before, ::after')){
-                    style.remove();
-                    is_removed_default_style = true;
-                }
-            });
-        }
-
-        //ダークモード検出&設定
-        const color_scheme = window.matchMedia('(prefers-color-scheme: dark)');
-        const main_element = document.getElementById("opd_main_element");
-        if(!main_element) return;
-
-        const color_mode = get_cookie_color_mode();
-
-        switch (color_mode){
-            case "system": {
-                apply_ui_color = () => {
-                    const currentScheme = color_scheme.matches ? "dark" : "light";
-                    main_element.setAttribute("opd-dsp-theme", currentScheme);
-                };
-        
-                // 初回反映
-                apply_ui_color();
-        
-                // system 指定時のみ、OS側のカラーモード変更に追従
-                if(!is_added_system_color_mode){
-                    color_scheme.addEventListener("change", apply_ui_color);
-                    is_added_system_color_mode = true;
-                    }
-                break;
-            }
-            case "light":
-                // system の監視が残ってたら解除
-                if(is_added_system_color_mode && apply_ui_color){
-                    color_scheme.removeEventListener("change", apply_ui_color);
-                    is_added_system_color_mode = false;
-                }
-                main_element.setAttribute("opd-dsp-theme", "light");
-                break;
-
-            case "dark":
-                if(is_added_system_color_mode && apply_ui_color){
-                    color_scheme.removeEventListener("change", apply_ui_color);
-                    is_added_system_color_mode = false;
-                }
-                main_element.setAttribute("opd-dsp-theme", "dark");
-                break;
-                
-            default:
-                break;
-        }
-
-    }).observe(document.querySelector("head"),{
-        childList: true,
-        characterData: true,
-        subtree: false
-    });
 }
+
+//MutationObserverを仕掛ける
+function observe_when_ready(get_target, watch_root, observer_callback, observer_options){
+    const target = get_target();
+    if(target){
+        //既に存在していたらすぐに仕掛ける
+        observer_callback(target);
+        new MutationObserver(() => observer_callback(target)).observe(target, observer_options);
+        return;
+    }
+
+    if(!watch_root) return;
+
+    const wait_observer = new MutationObserver(() => {
+        const target_retry = get_target();
+        if(target_retry){
+            wait_observer.disconnect();
+            observer_callback(target_retry);
+            new MutationObserver(() => observer_callback(target_retry)).observe(target_retry, observer_options);
+        }
+    });
+    wait_observer.observe(watch_root, { childList: true });
+}
+
+//カラー・CSS周りを設定する
+function head_observer_callback(head_elem){
+    //デフォルトのCSSがUIに影響を与えないように削除する
+    if(!is_removed_default_style){
+        head_elem.querySelectorAll('style').forEach(style => {
+            if(style.textContent.includes('*, ::before, ::after')){
+                style.remove();
+                is_removed_default_style = true;
+            }
+        });
+    }
+
+    //ダークモード検出&設定
+    const color_scheme = window.matchMedia('(prefers-color-scheme: dark)');
+    const main_element = document.getElementById("opd_main_element");
+    if(!main_element) return;
+
+    const color_mode = get_cookie_color_mode();
+    switch (color_mode){
+        case "system": {
+            apply_ui_color = () => {
+                const currentScheme = color_scheme.matches ? "dark" : "light";
+                main_element.setAttribute("opd-dsp-theme", currentScheme);
+            };
+            apply_ui_color();
+            if(!is_added_system_color_mode){
+                color_scheme.addEventListener("change", apply_ui_color);
+                is_added_system_color_mode = true;
+            }
+            break;
+        }
+        case "light":
+            if(is_added_system_color_mode && apply_ui_color){
+                color_scheme.removeEventListener("change", apply_ui_color);
+                is_added_system_color_mode = false;
+            }
+            main_element.setAttribute("opd-dsp-theme", "light");
+            break;
+        case "dark":
+            if(is_added_system_color_mode && apply_ui_color){
+                color_scheme.removeEventListener("change", apply_ui_color);
+                is_added_system_color_mode = false;
+            }
+            main_element.setAttribute("opd-dsp-theme", "dark");
+            break;
+        default:
+            break;
+    }
+}
+
+//メインX動作マスク
+function main_dsp(react_root){
+    if(!react_root) return;
+    react_root.style.visibility = "hidden";
+    react_root.style.overflow = "hidden";
+}
+
+//タイトルやfaviconを設定する
+function set_title_favicon(){
+    const OPD_TITLE = "Open-Deck";
+    const OPD_FAVICON_URL = chrome.runtime.getURL("icon.png");
+
+    //タイトルを設定する
+    document.head.querySelectorAll("title").forEach(elem => {
+        if(elem.dataset.opd !== "1") elem.remove();
+    });
+    let opd_title = document.head.querySelector('title[data-opd="1"]');
+    if(!opd_title){
+        opd_title = document.createElement("title");
+        opd_title.dataset.opd = "1";
+        opd_title.textContent = OPD_TITLE;
+        document.head.appendChild(opd_title);
+    }
+
+    //titleを監視
+    const title_observer = new MutationObserver(() => {
+        //自分の title の中身が変わっていたら戻す
+        if(opd_title.textContent !== OPD_TITLE){
+            opd_title.textContent = OPD_TITLE;
+        }
+        document.head.querySelectorAll("title").forEach(elem => {
+            if(elem.dataset.opd !== "1") elem.remove();
+        });
+    });
+    title_observer.observe(opd_title, {
+        childList: true,
+        characterData: true,
+        subtree: true
+    });
+    //headも監視
+    const head_title_observer = new MutationObserver(mutations => {
+        for(const m of mutations){
+            for(const node of m.addedNodes){
+                if(node.tagName === "TITLE" && node.dataset.opd !== "1"){
+                    node.remove();
+                }
+            }
+        }
+    });
+    head_title_observer.observe(document.head, { childList: true });
+
+    //faviconを設定する
+    document.head.querySelectorAll('link[rel="shortcut icon"], link[rel="icon"]').forEach(l => {
+        if(l.dataset.opd !== "1") l.remove();
+    });
+    let opd_favicon = document.head.querySelector('link[data-opd="1"]');
+    if(!opd_favicon){
+        opd_favicon = document.createElement("link");
+        opd_favicon.rel = "shortcut icon";
+        opd_favicon.href = OPD_FAVICON_URL;
+        opd_favicon.dataset.opd = "1";
+        document.head.appendChild(opd_favicon);
+    }
+
+    //favicon監視
+    const favicon_observer = new MutationObserver(() => {
+        if(opd_favicon.getAttribute("href") !== OPD_FAVICON_URL){
+            opd_favicon.setAttribute("href", OPD_FAVICON_URL);
+        }
+    });
+    favicon_observer.observe(opd_favicon, {
+        attributes: true,
+        attributeFilter: ["href", "rel"]
+    });
+    //head自体も監視
+    const head_favicon_observer = new MutationObserver(mutations => {
+        for(const m of mutations){
+            for(const node of m.addedNodes){
+                if(node.tagName === "LINK"
+                    && (node.rel === "shortcut icon" || node.rel === "icon")
+                    && node.dataset.opd !== "1"){
+                    node.remove();
+                }
+            }
+        }
+    });
+    head_favicon_observer.observe(document.head, { childList: true });
+}
+
 //Cookieからカラーモードを取得する
 function get_cookie_color_mode() {
     const cookie = document.cookie.split(/;\s*/).find(c => c.startsWith('night_mode='));

--- a/content.js
+++ b/content.js
@@ -17,7 +17,10 @@ let profile_store;
 let last_load_profile = 0;
 let is_removed_default_style = false;
 let media_viewer_token = [];
-const column_auto_update_state = {date:0, is_stop:false};
+const column_auto_update_state = {
+    text_focus: {date: 0, active: false},
+    media_viewer: {active: false},
+};
 const ui_icon_define = {
     banner_hide:"icon/banner_hide.svg",
     top_bar_hide:"icon/top_hide.svg",
@@ -202,13 +205,11 @@ function run(settings){
     //カラム全体のテキストフォーカスの状態で自動更新を制御できるようにする
     window.addEventListener('opd_post_focus', (e) => {
         if(e.detail){
-            console.log("focus", e.detail)
-            column_auto_update_state.date = Date.now();
-            column_auto_update_state.is_stop = true;
-
+            column_auto_update_state.text_focus.date = Date.now();
+            column_auto_update_state.text_focus.active = true;
         }else{
-            column_auto_update_state.date = 0;
-            column_auto_update_state.is_stop = false;
+            column_auto_update_state.text_focus.date = 0;
+            column_auto_update_state.text_focus.active = false;
         }
     });
     //画像表示パネル
@@ -218,7 +219,13 @@ function run(settings){
         for (let index = 0; index < media_viewer_token.length; index++) {
             const token = media_viewer_token[index];
             if(detail.token === token){
-                media_viewer.Preview(detail.media_info, detail.selected_index);
+                //ビューワーを閉じた際のコールバック関数
+                function viewer_close(){
+                    column_auto_update_state.media_viewer.active = false;
+                }
+                
+                column_auto_update_state.media_viewer.active = true;
+                media_viewer.Preview(detail.media_info, detail.selected_index, viewer_close);
                 break;
             }
         }
@@ -1235,7 +1242,7 @@ function run(settings){
                                 if(['/home', '/search'].includes(path_name) || path_name.startsWith('/i/lists')){
                                     if(auto_reload_target_elem.getAttribute("auto_reload_mouse_hover") == "false"){
                                         //カラムの自動更新が全体的に許可されていない場合は自動更新を無効化する
-                                        if (auto_reload_target_elem.opd_auto_reload && !is_auto_update()){
+                                        if (auto_reload_target_elem.opd_auto_reload && is_auto_update()){
                                             auto_reload_target_elem.opd_auto_reload.Reload(auto_reload_target_elem.contentWindow);
                                             setTimeout(() => {
                                                 auto_reload_target_elem.contentWindow.scrollTo({ top: 0, behavior: 'auto' });
@@ -1335,7 +1342,7 @@ function run(settings){
                                         if(['/home', '/search'].includes(path_name) || path_name.startsWith('/i/lists')){
                                             if(auto_reload_target_object.getAttribute("auto_reload_mouse_hover") == "false"){
                                                 //カラムの自動更新が全体的に許可されていない場合は自動更新を無効化する
-                                                if (auto_reload_target_object.opd_auto_reload && !is_auto_update()){
+                                                if (auto_reload_target_object.opd_auto_reload && is_auto_update()){
                                                     auto_reload_target_object.opd_auto_reload.Reload(auto_reload_target_object.contentWindow);
                                                     setTimeout(() => {
                                                         auto_reload_target_object.contentWindow.scrollTo({ top: 0, behavior: 'auto' });
@@ -1810,18 +1817,26 @@ function run(settings){
         }
     }
     //自動更新許可を取得する関数
-    function is_auto_update(){
-        console.log(column_auto_update_state)
-        if(!column_auto_update_state.is_stop) return false;
-
-        //フォーカスが一定時間以上継続している場合は更新不良とみなして状態をリセットする
-        /*const FOCUS_STALE_MS = 5 * 60 * 1000;
-        if (Date.now() - column_auto_update_state.date > FOCUS_STALE_MS) {
-            column_auto_update_state.date = 0;
-            column_auto_update_state.is_stop = false;
+    function is_auto_update(stale_check = false){
+        //テキスト入力フォーカス中
+        if(column_auto_update_state.text_focus.active){
+            if (stale_check){
+                //一定時間以上継続している場合は更新不良とみなしてリセット
+                const FOCUS_STALE_MS = 5 * 60 * 1000;
+                if(Date.now() - column_auto_update_state.text_focus.date > FOCUS_STALE_MS){
+                    column_auto_update_state.text_focus.date = 0;
+                    column_auto_update_state.text_focus.active = false;
+                }else{
+                    return false;
+                }
+            }else{
+                return false;
+            }
+        }
+        //メディアビューワー表示中
+        if(column_auto_update_state.media_viewer.active){
             return false;
-        }*/
-
+        }
         return true;
     }
     //ランダムID作成

--- a/content.js
+++ b/content.js
@@ -17,6 +17,7 @@ let profile_store;
 let last_load_profile = 0;
 let is_removed_default_style = false;
 let media_viewer_token = [];
+const colum_text_focus = {date:0, is_focus:false};
 const ui_icon_define = {
     banner_hide:"icon/banner_hide.svg",
     top_bar_hide:"icon/top_hide.svg",
@@ -198,6 +199,18 @@ function run(settings){
     }
     profile_list_html = `<div class="profile_val_now" title="${i18n_message("ui_profile_current_title")}">${last_load_profile}</div><div class="dsp_profile_list"><div id="profile_btn_list">${profile_list_btn_html}</div>`;
     //console.log(profile_list_btn_html)
+    //カラム全体のテキストフォーカスの状態
+    window.addEventListener('opd_post_focus', (e) => {
+        if(e.detail){
+            console.log("focus", e.detail)
+            colum_text_focus.date = Date.now();
+            colum_text_focus.is_focus = true;
+
+        }else{
+            colum_text_focus.date = 0;
+            colum_text_focus.is_focus = false;
+        }
+    });
     //画像表示パネル
     const media_viewer = new OpdExtMediaViewer();
     document.addEventListener('opd_send_media_info', (e) => {
@@ -1221,7 +1234,8 @@ function run(settings){
                                 const path_name = auto_reload_target_elem.contentWindow.location.pathname;
                                 if(['/home', '/search'].includes(path_name) || path_name.startsWith('/i/lists')){
                                     if(auto_reload_target_elem.getAttribute("auto_reload_mouse_hover") == "false"){
-                                        if (auto_reload_target_elem.opd_auto_reload){
+                                        //他カラムでテキスト編集中の場合は上部移動を無効化する
+                                        if (auto_reload_target_elem.opd_auto_reload && !is_focus()){
                                             auto_reload_target_elem.opd_auto_reload.Reload(auto_reload_target_elem.contentWindow);
                                             setTimeout(() => {
                                                 auto_reload_target_elem.contentWindow.scrollTo({ top: 0, behavior: 'auto' });
@@ -1320,7 +1334,8 @@ function run(settings){
                                         const path_name = auto_reload_target_object.contentWindow.location.pathname;
                                         if(['/home', '/search'].includes(path_name) || path_name.startsWith('/i/lists')){
                                             if(auto_reload_target_object.getAttribute("auto_reload_mouse_hover") == "false"){
-                                                if (auto_reload_target_object.opd_auto_reload){
+                                                //他カラムでテキスト編集中の場合は上部移動を無効化する
+                                                if (auto_reload_target_object.opd_auto_reload && !is_focus()){
                                                     auto_reload_target_object.opd_auto_reload.Reload(auto_reload_target_object.contentWindow);
                                                     setTimeout(() => {
                                                         auto_reload_target_object.contentWindow.scrollTo({ top: 0, behavior: 'auto' });
@@ -1584,11 +1599,8 @@ function run(settings){
                             document.querySelector(".profile_val_now").textContent = after_profile_num;
                             document.querySelector("#profile_btn_list").innerHTML = profile_list_btn_html;
                             create_profile_list_btn();
-                            });
                         });
-                    //last_load_profile
-                    //
-                    //.aaaa
+                    });
                 });
             }
         }else{
@@ -1796,6 +1808,21 @@ function run(settings){
                 //console.log(settings_array);
             });
         }
+    }
+    //カラム全体のフォーカス状態を取得する関数
+    function is_focus(){
+        console.log(colum_text_focus)
+        if(!colum_text_focus.is_focus) return false;
+
+        //フォーカスが一定時間以上継続している場合は更新不良とみなして状態をリセットする
+        /*const FOCUS_STALE_MS = 5 * 60 * 1000;
+        if (Date.now() - colum_text_focus.date > FOCUS_STALE_MS) {
+            colum_text_focus.date = 0;
+            colum_text_focus.is_focus = false;
+            return false;
+        }*/
+
+        return true;
     }
     //ランダムID作成
     function create_random_id(){

--- a/content.js
+++ b/content.js
@@ -1595,7 +1595,7 @@ function run(settings){
             alert(i18n_message("msg_profile_delete_current_alert"));
         }
     });
-    //カラム拡張機能の初期化
+    //カラム拡張機能の初期化(カラム拡張機能追加はここで行います)
     function reinit_column_extensions(column_div){
         const column_frame = column_div?.querySelector("iframe");
         if(!column_frame) return;

--- a/content.js
+++ b/content.js
@@ -1042,6 +1042,7 @@ function run(settings){
 
                 //カラム拡張読み込み
                 if(mode != "session_set"){
+                    this.opd_ext_initialized = false;
                     reinit_column_extensions(this.closest("div[opd_column_type]"));
                 }
 
@@ -1620,6 +1621,8 @@ function run(settings){
         if(!column_frame) return;
         const column_type = column_div.getAttribute("opd_column_type");
 
+        if(column_frame.opd_ext_initialized) return;
+
         let initialized = false;
         const doInit = () => {
             if(initialized) return;
@@ -1627,6 +1630,8 @@ function run(settings){
 
             if(target_window && (!target_window.document || !target_window.document.head)) return;
             initialized = true;
+
+            column_frame.opd_ext_initialized = true;
 
             //ユーティリティを仕込む
             const opd_utils = new OpdUtils();
@@ -1652,16 +1657,22 @@ function run(settings){
             }
         };
 
-        column_frame.addEventListener("load", doInit, { once: true });
-
-        //loadが発火しない場合にフォールバックする
-        setTimeout(doInit, 500);
+        if(column_frame.contentDocument?.readyState === "complete"){
+            doInit();
+        }else{
+            column_frame.addEventListener("load", doInit, { once: true });
+        }
     }
+
     //カラム移動
     function column_dd(){
         let column_class = document.querySelectorAll(".dsp_column");
         let column_copy_source = null;
         for (let index = 0; index < column_class.length; index++) {
+            //既にD&Dが登録済みのカラムはスキップ
+            if(column_class[index].dataset.opd_dd_initialized === "1") continue;
+            column_class[index].dataset.opd_dd_initialized = "1";
+        
             column_class[index].addEventListener("dragstart", function(ev){
                 //console.log(this)
                 column_copy_source = this;
@@ -1676,56 +1687,53 @@ function run(settings){
             });
             column_class[index].addEventListener("drop", function(ev){
                 ev.preventDefault();
-                //移動時初期表示設定
-                //bn_twview_mode(this.querySelector("iframe"));
-                //exploreのURLセット
-                //console.log(column_class[index])
-                //移動セット
                 const dt_id = ev.dataTransfer.getData('text/plain');
                 const dr_elem = document.getElementById(dt_id);
                 if(dr_elem != null){
                     if(dr_elem?.querySelector("div")?.getAttribute("opd_column_type") == 'explore'){
-                        // && dr_elem.querySelector("div").querySelector("iframe").src != `https://x.com${dr_elem.querySelector("div").getAttribute("opd_explore_path")}`
-                        //console.log(dr_elem.querySelector("div").getAttribute("opd_explore_path"))
-                        //console.log(dr_elem.querySelector("div").getAttribute("opd_pinned_path"))
                         if(dr_elem.querySelector("div").getAttribute("opd_pinned_path") != ""){
-                            //console.log("Pinned")
                             dr_elem.querySelector("div").querySelector("iframe").src = `https://x.com${dr_elem.querySelector("div").getAttribute("opd_pinned_path")}`;
                         }else{
-                           //console.log("Exp_save")
                             dr_elem.querySelector("div").querySelector("iframe").src = `https://x.com${dr_elem.querySelector("div").getAttribute("opd_explore_path")}`;
                         }
                     }
                     this.parentNode.insertBefore(dr_elem, this);
                     this.style.borderLeft = '';
-                    //append_object_css();
-                    //column_dd();
 
-                    reinit_column_extensions(dr_elem.querySelector("div[opd_column_type]"));
+                    //ロード完了を待って拡張機能を再初期化する
+                    const moved_column_div = dr_elem.querySelector("div[opd_column_type]");
+                    const moved_iframe = moved_column_div?.querySelector("iframe");
+                    if(moved_iframe){
+                        moved_iframe.opd_ext_initialized = false;
+                        moved_iframe.addEventListener("load", () => {
+                            reinit_column_extensions(moved_column_div);
+                        }, { once: true });
+                    }
 
                     column_settings_save("", last_load_profile);
                 }else{
                     this.style.borderLeft = '';
                 }
-                
             })
         }
     }
     //カラム終了
     function column_close(){
-        for (let index = 0; index < document.querySelectorAll(".column_close_btn").length; index++) {
-            document.querySelectorAll(".column_close_btn")[index].addEventListener("click", function(){
+        const close_btns = document.querySelectorAll(".column_close_btn");
+        for (let index = 0; index < close_btns.length; index++) {
+            //既にイベントが登録済みのカラムはスキップ
+            if(close_btns[index].dataset.opd_close_initialized === "1") continue;
+                close_btns[index].dataset.opd_close_initialized = "1";
+                close_btns[index].addEventListener("click", function(){
                 const pin_checkbox = this.closest(".dsp_column").querySelector(".opd_pinned_btn")?.checked;
                 if(pin_checkbox == false || pin_checkbox == undefined){
                     this.closest(".dsp_column").remove();
                     append_object_css();
-                    //column_dd();
                     column_settings_save("", last_load_profile);
                 }else{
                     if(confirm(i18n_message("msg_pinned_column_close_confirm"))){
                         this.closest(".dsp_column").remove();
                         append_object_css();
-                        //column_dd();
                         column_settings_save("", last_load_profile);
                     }
                 }

--- a/content.js
+++ b/content.js
@@ -1609,11 +1609,11 @@ function run(settings){
             if(target_window && (!target_window.document || !target_window.document.head)) return;
             initialized = true;
 
-            //ユーティリティ仕込み
+            //ユーティリティを仕込む
             const opd_utils = new OpdUtils();
             opd_utils.Init(target_window);
 
-            //文章校正機能を組み込む
+            //文章校正機能を仕込む
             if(column_type === "post"){
                 const ext_text_review = new OpdExtTextReview();
                 const ui_lang = chrome.i18n.getUILanguage();

--- a/content.js
+++ b/content.js
@@ -17,7 +17,7 @@ let profile_store;
 let last_load_profile = 0;
 let is_removed_default_style = false;
 let media_viewer_token = [];
-const colum_text_focus = {date:0, is_focus:false};
+const column_auto_update_state = {date:0, is_stop:false};
 const ui_icon_define = {
     banner_hide:"icon/banner_hide.svg",
     top_bar_hide:"icon/top_hide.svg",
@@ -199,16 +199,16 @@ function run(settings){
     }
     profile_list_html = `<div class="profile_val_now" title="${i18n_message("ui_profile_current_title")}">${last_load_profile}</div><div class="dsp_profile_list"><div id="profile_btn_list">${profile_list_btn_html}</div>`;
     //console.log(profile_list_btn_html)
-    //カラム全体のテキストフォーカスの状態
+    //カラム全体のテキストフォーカスの状態で自動更新を制御できるようにする
     window.addEventListener('opd_post_focus', (e) => {
         if(e.detail){
             console.log("focus", e.detail)
-            colum_text_focus.date = Date.now();
-            colum_text_focus.is_focus = true;
+            column_auto_update_state.date = Date.now();
+            column_auto_update_state.is_stop = true;
 
         }else{
-            colum_text_focus.date = 0;
-            colum_text_focus.is_focus = false;
+            column_auto_update_state.date = 0;
+            column_auto_update_state.is_stop = false;
         }
     });
     //画像表示パネル
@@ -1234,8 +1234,8 @@ function run(settings){
                                 const path_name = auto_reload_target_elem.contentWindow.location.pathname;
                                 if(['/home', '/search'].includes(path_name) || path_name.startsWith('/i/lists')){
                                     if(auto_reload_target_elem.getAttribute("auto_reload_mouse_hover") == "false"){
-                                        //他カラムでテキスト編集中の場合は上部移動を無効化する
-                                        if (auto_reload_target_elem.opd_auto_reload && !is_focus()){
+                                        //カラムの自動更新が全体的に許可されていない場合は自動更新を無効化する
+                                        if (auto_reload_target_elem.opd_auto_reload && !is_auto_update()){
                                             auto_reload_target_elem.opd_auto_reload.Reload(auto_reload_target_elem.contentWindow);
                                             setTimeout(() => {
                                                 auto_reload_target_elem.contentWindow.scrollTo({ top: 0, behavior: 'auto' });
@@ -1334,8 +1334,8 @@ function run(settings){
                                         const path_name = auto_reload_target_object.contentWindow.location.pathname;
                                         if(['/home', '/search'].includes(path_name) || path_name.startsWith('/i/lists')){
                                             if(auto_reload_target_object.getAttribute("auto_reload_mouse_hover") == "false"){
-                                                //他カラムでテキスト編集中の場合は上部移動を無効化する
-                                                if (auto_reload_target_object.opd_auto_reload && !is_focus()){
+                                                //カラムの自動更新が全体的に許可されていない場合は自動更新を無効化する
+                                                if (auto_reload_target_object.opd_auto_reload && !is_auto_update()){
                                                     auto_reload_target_object.opd_auto_reload.Reload(auto_reload_target_object.contentWindow);
                                                     setTimeout(() => {
                                                         auto_reload_target_object.contentWindow.scrollTo({ top: 0, behavior: 'auto' });
@@ -1809,16 +1809,16 @@ function run(settings){
             });
         }
     }
-    //カラム全体のフォーカス状態を取得する関数
-    function is_focus(){
-        console.log(colum_text_focus)
-        if(!colum_text_focus.is_focus) return false;
+    //自動更新許可を取得する関数
+    function is_auto_update(){
+        console.log(column_auto_update_state)
+        if(!column_auto_update_state.is_stop) return false;
 
         //フォーカスが一定時間以上継続している場合は更新不良とみなして状態をリセットする
         /*const FOCUS_STALE_MS = 5 * 60 * 1000;
-        if (Date.now() - colum_text_focus.date > FOCUS_STALE_MS) {
-            colum_text_focus.date = 0;
-            colum_text_focus.is_focus = false;
+        if (Date.now() - column_auto_update_state.date > FOCUS_STALE_MS) {
+            column_auto_update_state.date = 0;
+            column_auto_update_state.is_stop = false;
             return false;
         }*/
 

--- a/extensions/auto_reload_helper.js
+++ b/extensions/auto_reload_helper.js
@@ -2,7 +2,7 @@
 (() => {
     let path_old = null;
     let opd_reload_token = null;
-    let reload_func = null;
+    let reload_func = ()=>{};
     // URLで画面の遷移を監視する
     new MutationObserver(function(){
         const path_search = `${location.pathname}${location.search}`;
@@ -14,12 +14,12 @@
         if(!section) return;
         //Propsを取得する
         const props = get_props(section, "Props");
-        const refresh = props?.children[1]?.props.children[2]?._owner.memoizedProps?.onRefresh;
+        const refresh = props?.children[1]?.props.children[2]?._owner?.memoizedProps?.onRefresh;
         if (!refresh){
             // 関数が存在しない場合、無意味な関数を設定しておく
             reload_func = ()=>{};
             return;
-        };
+        }
         reload_func = refresh;
         path_old = path_search;
     }).observe(document, {childList: true, subtree: true});
@@ -31,13 +31,24 @@
     }
     //機能動作用のトークンを設定
     window.addEventListener('opd_column_reload_init', (e)=>{
-        const detail = JSON.parse(e.detail);
-        opd_reload_token = detail.token;
+        try {
+            const detail = JSON.parse(e.detail);
+            opd_reload_token = detail.token;
+        } catch (err) {
+            console.warn('invalid init detail->', err);
+        }
     }, true);
     //自動更新イベントを追加する
     window.addEventListener('opd_column_reload', (e) => {
         const detail = JSON.parse(e.detail);
         if(opd_reload_token && opd_reload_token !== detail.token) return;
-        reload_func();
+
+        if(typeof reload_func !== 'function') return;
+
+        try {
+            reload_func();
+        } catch (err) {
+            console.warn('reload_func threw->', err);
+        }
     }, true);
 })();

--- a/extensions/media_viewer/media_viewer.js
+++ b/extensions/media_viewer/media_viewer.js
@@ -1,7 +1,7 @@
 // メディアビューワー
 class OpdExtMediaViewer {
     constructor() {
-        this.Preview = (media_info, pre_index) => {
+        this.Preview = (media_info, pre_index, callback=()=>{}) => {
             let current_media_idx = pre_index;
             const media_viewer_div = document.createElement("div");
             const media_viewer_dialog = document.createElement("dialog");
@@ -112,6 +112,9 @@ class OpdExtMediaViewer {
                     video_element.remove();
                 }
                 media_viewer_div.remove();
+
+                //callbackを実行する
+                callback();
             }
 
             media_viewer_dialog.addEventListener("close", () => media_viewer_close());

--- a/extensions/media_viewer_block.js
+++ b/extensions/media_viewer_block.js
@@ -14,26 +14,6 @@ class OpdMediaViewerBlocker {
                     composed: true,
                     detail: JSON.stringify({ token: this.opd_send_media_info_token })
                 }));
-
-                /*ショートカットキーとしてAlt(Option)キーの動作を設定*/
-                document.addEventListener('keydown', (event) => {
-                    if(event.key === 'Alt'){
-                        column_window.document.dispatchEvent(new CustomEvent('opd_media_viewer_shotcut', {
-                            bubbles: true,
-                            composed: true,
-                            detail: JSON.stringify({token: this.opd_send_media_info_token, keys:{alt:true}})
-                        }));
-                    }
-                });
-                document.addEventListener('keyup', (event) => {
-                    if(event.key === 'Alt'){
-                        column_window.document.dispatchEvent(new CustomEvent('opd_media_viewer_shotcut', {
-                            bubbles: true,
-                            composed: true,
-                            detail: JSON.stringify({token: this.opd_send_media_info_token, keys:{alt:false}})
-                        }));
-                    }
-                });
             });
 
             column_window.document.head.appendChild(helper_script);

--- a/extensions/media_viewer_block_helper.js
+++ b/extensions/media_viewer_block_helper.js
@@ -1,7 +1,6 @@
 //メディアビューワー停止用
 (() => {
     let opd_send_media_info_token = null;
-    let is_alt_pressed = false;
     //カラム側の画像表示を停止させて、表示画像などの情報をOPD側に渡す
     /*
     TODO:ツイートページのツイートに画像や動画付きの引用が付いていて、引用のメディアをクリックした際に元のメディアが表示される問題を修正する。
@@ -9,7 +8,18 @@
     */
     document.addEventListener("click", (e) => {
         //Alt(Option)キーが押されている場合はメディアビューワーを使用しないようにする
-        if(is_alt_pressed) return;
+        if (e.altKey) {
+            const target_root = e.target.closest('div[data-testid="cellInnerDiv"]');
+            if (target_root) {
+                e.preventDefault();
+                e.stopPropagation();
+                e.stopImmediatePropagation();
+            
+                const target = e.target.closest('a[href]')
+                target.click();
+            }
+            return;
+        }
 
         //引用の場合に格納される
         const quoted = e.target.closest('div[tabindex="0"][role="link"]');
@@ -101,22 +111,4 @@
         const detail = JSON.parse(e.detail);
         opd_send_media_info_token = detail.token;
     }, true);
-    /*ショートカットキーとしてAlt(Option)キーの動作を設定*/
-    document.addEventListener('opd_media_viewer_shotcut', (e)=>{
-        //カラムが非アクティブの場合
-        const detail = JSON.parse(e.detail);
-
-        if(detail.token !== opd_send_media_info_token) return;
-
-        is_alt_pressed = detail.keys.alt;
-    }, true);
-    //カラムがアクティブの場合
-    document.addEventListener('keydown', (event) => {
-        console.log("shift_down")
-        if (event.key === 'Alt') is_alt_pressed = true;
-    });
-    document.addEventListener('keyup', (event) => {
-        console.log("shift_up")
-        if (event.key === 'Alt') is_alt_pressed = false;
-    });
 })();

--- a/extensions/media_viewer_block_helper.js
+++ b/extensions/media_viewer_block_helper.js
@@ -16,7 +16,9 @@
                 e.stopImmediatePropagation();
             
                 const target = e.target.closest('a[href]')
-                target.click();
+                if (target){
+                    target.click();
+                }
             }
             return;
         }

--- a/extensions/text_review_helper.js
+++ b/extensions/text_review_helper.js
@@ -2,14 +2,14 @@
 (() => {
     const isAllowed = (u) => {
         const url = new URL(u, location.href);
-        return url.origin === location.origin && url.pathname.startsWith("/compose/post");
+        return url.origin === location.origin && url.pathname.startsWith("/intent/tweet");
     };
     //GIF ボタンを消す
     document.querySelector("head").insertAdjacentHTML("beforeend", `<style opd_post_css>main button[data-testid="gifSearchButton"]{display:none;}div[data-testid="twc-cc-mask"]{display:none;}</style>`);
     new MutationObserver(function(){
         const back_button = document.querySelector('main button[data-testid="app-bar-back"]');
         if(!back_button) return;
-        if(location.pathname === "/compose/post"){
+        if(location.pathname === "/intent/tweet"){
             back_button.style.display = "none";
         }else{
             back_button.style.display = "block";

--- a/extensions/utils.js
+++ b/extensions/utils.js
@@ -1,0 +1,11 @@
+// メディアビューワー停止用
+class OpdUtils {
+    constructor() {
+        this.Init = (column_window) => {
+            //ヘルパースクリプト追加
+            const helper_script = column_window.document.createElement('script');
+            helper_script.src = chrome.runtime.getURL("extensions/utils_helper.js");
+            column_window.document.head.appendChild(helper_script);
+        }
+    }
+}

--- a/extensions/utils_helper.js
+++ b/extensions/utils_helper.js
@@ -4,16 +4,18 @@
     /* ポスト画面などテキスト入力フォーカス状態を送信するようにする関数 */
     function sendTextFocusState(){
         //フォーカスされた時
-        document.addEventListener('focusin', (e) => {
+        window.addEventListener('focusin', (e) => {
             if (e.target.getAttribute('contenteditable') === 'true' || e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') {
                 console.log("focus")
                 window.dispatchEvent(new CustomEvent('opd_post_focus', {detail: true}));
             }
         });
         //フォーカスが外れた時
-        document.addEventListener('focusout', (e) => {
+        window.addEventListener('focusout', (e) => {
             console.log("focus-out")
             window.dispatchEvent(new CustomEvent('opd_post_focus', {detail: false}));
         });
     }
+
+    sendTextFocusState();
 })();

--- a/extensions/utils_helper.js
+++ b/extensions/utils_helper.js
@@ -6,14 +6,12 @@
         //フォーカスされた時
         window.addEventListener('focusin', (e) => {
             if (e.target.getAttribute('contenteditable') === 'true' || e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') {
-                console.log("focus")
-                window.dispatchEvent(new CustomEvent('opd_post_focus', {detail: true}));
+                window.parent.dispatchEvent(new CustomEvent('opd_post_focus', {detail: true}));
             }
         });
         //フォーカスが外れた時
         window.addEventListener('focusout', (e) => {
-            console.log("focus-out")
-            window.dispatchEvent(new CustomEvent('opd_post_focus', {detail: false}));
+            window.parent.dispatchEvent(new CustomEvent('opd_post_focus', {detail: false}));
         });
     }
 

--- a/extensions/utils_helper.js
+++ b/extensions/utils_helper.js
@@ -1,0 +1,19 @@
+/* カラム内で使う細々とした機能を実装する */
+(() => {
+    console.log("UtilsWorking")
+    /* ポスト画面などテキスト入力フォーカス状態を送信するようにする関数 */
+    function sendTextFocusState(){
+        //フォーカスされた時
+        document.addEventListener('focusin', (e) => {
+            if (e.target.getAttribute('contenteditable') === 'true' || e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') {
+                console.log("focus")
+                window.dispatchEvent(new CustomEvent('opd_post_focus', {detail: true}));
+            }
+        });
+        //フォーカスが外れた時
+        document.addEventListener('focusout', (e) => {
+            console.log("focus-out")
+            window.dispatchEvent(new CustomEvent('opd_post_focus', {detail: false}));
+        });
+    }
+})();

--- a/extensions/utils_helper.js
+++ b/extensions/utils_helper.js
@@ -6,12 +6,12 @@
         //フォーカスされた時
         window.addEventListener('focusin', (e) => {
             if (e.target.getAttribute('contenteditable') === 'true' || e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') {
-                window.parent.dispatchEvent(new CustomEvent('opd_post_focus', {detail: true}));
+                window.parent.dispatchEvent(new CustomEvent('opd_post_focus', {detail: JSON.stringify(true)}));
             }
         });
         //フォーカスが外れた時
         window.addEventListener('focusout', (e) => {
-            window.parent.dispatchEvent(new CustomEvent('opd_post_focus', {detail: false}));
+            window.parent.dispatchEvent(new CustomEvent('opd_post_focus', {detail: JSON.stringify(false)}));
         });
     }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Open-Deck",
-  "version": "1.1.3.2",
+  "version": "1.1.3.3",
   "manifest_version": 3,
   "description": "The OpenSource Deck",
   "default_locale": "ja",
@@ -17,7 +17,7 @@
   "background" : {"service_worker" : "background.js"},
   "content_scripts": [{
     "matches": ["https://*.twitter.com/*", "https://*.x.com/*"],
-    "js": ["content.js", "extensions/text_review.js", "extensions/auto_reload.js", "extensions/media_viewer_block.js", "extensions/media_viewer/media_viewer.js"]
+    "js": ["content.js", "extensions/utils_helper.js", "extensions/text_review.js", "extensions/auto_reload.js", "extensions/media_viewer_block.js", "extensions/media_viewer/media_viewer.js"]
   }],
   "web_accessible_resources" : [{
     "matches" : ["https://*.twitter.com/*", "https://*.x.com/*"],

--- a/manifest.json
+++ b/manifest.json
@@ -17,11 +17,12 @@
   "background" : {"service_worker" : "background.js"},
   "content_scripts": [{
     "matches": ["https://*.twitter.com/*", "https://*.x.com/*"],
-    "js": ["content.js", "extensions/utils_helper.js", "extensions/text_review.js", "extensions/auto_reload.js", "extensions/media_viewer_block.js", "extensions/media_viewer/media_viewer.js"]
+    "js": ["content.js", "extensions/utils.js", "extensions/text_review.js", "extensions/auto_reload.js", "extensions/media_viewer_block.js", "extensions/media_viewer/media_viewer.js"]
   }],
   "web_accessible_resources" : [{
     "matches" : ["https://*.twitter.com/*", "https://*.x.com/*"],
     "resources" : [
+    "extensions/utils_helper.js",
     "extensions/text_review_helper.js",
     "extensions/auto_reload_helper.js",
     "extensions/media_viewer_block_helper.js",

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,8 @@
   ],
   "permissions" : ["storage","webRequest","declarativeNetRequest"],
   "background" : {"service_worker" : "background.js"},
-  "content_scripts": [{
+  "content_scripts": [
+  {
     "matches": ["https://*.twitter.com/*", "https://*.x.com/*"],
     "js": ["content.js", "extensions/utils.js", "extensions/text_review.js", "extensions/auto_reload.js", "extensions/media_viewer_block.js", "extensions/media_viewer/media_viewer.js"]
   }],

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,6 +1,6 @@
 {
     "name": "Open-Deck",
-    "version": "1.1.3.2",
+    "version": "1.1.3.3",
     "manifest_version": 2,
     "description": "The OpenSource Deck",
     "default_locale": "ja",
@@ -63,7 +63,7 @@
     ],
     "content_scripts": [{
       "matches": ["https://twitter.com/*", "https://x.com/*"],
-      "js": ["content.js", "extensions/text_review.js", "extensions/auto_reload.js", "extensions/media_viewer_block.js", "extensions/media_viewer/media_viewer.js"]
+      "js": ["content.js", "extensions/utils_helper.js", "extensions/text_review.js", "extensions/auto_reload.js", "extensions/media_viewer_block.js", "extensions/media_viewer/media_viewer.js"]
       }],
       "browser_action": {
         "default_popup": "popup.html",

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -18,6 +18,7 @@
       }
     },
     "web_accessible_resources": [
+    "extensions/utils_helper.js",
     "extensions/text_review_helper.js",
     "extensions/auto_reload_helper.js",
     "extensions/media_viewer_block_helper.js",
@@ -63,7 +64,7 @@
     ],
     "content_scripts": [{
       "matches": ["https://twitter.com/*", "https://x.com/*"],
-      "js": ["content.js", "extensions/utils_helper.js", "extensions/text_review.js", "extensions/auto_reload.js", "extensions/media_viewer_block.js", "extensions/media_viewer/media_viewer.js"]
+      "js": ["content.js", "extensions/utils.js", "extensions/text_review.js", "extensions/auto_reload.js", "extensions/media_viewer_block.js", "extensions/media_viewer/media_viewer.js"]
       }],
       "browser_action": {
         "default_popup": "popup.html",


### PR DESCRIPTION
## 追加されたもの / New features
なし

## 直したもの / Fixed items
- 起動時
  - Open-Deckを丸一日起動せずに放置した場合、カラムに「拒否された」などのメッセージが表示される問題を修正
- カラム自動更新 
  - ポストカラムで文字を入力中に自動更新のタイミングでテキストのフォーカスが外れてしまう問題を修正
  - 画像や動画の閲覧時でも自動更新され、ビューワーを閉じた後に最新のタイムラインに飛んでしまっている問題を修正
- カラム移動等
  - カラム移動後にメディアビューワーが動作しない問題や自動更新がされない問題を修正

- 細かな部分
  - タイトルやfaviconの変更・カラーモード検出で使用する状態変化の検出方法を変更した
  - Postカラム安定性を考慮して、内部で使うURLを伝統的に使われているものに変更

- DNRルール・設定の変更
  - 強力なルールを見直して、より安全な実装に変更した
    - ルールの適用範囲を限定し、Open-Deckの実装範囲外ではルールが適用されないようにした
  - カラム読み込み失敗を避けるために、より確実にルールが適用されるようにした
    - インストールや更新時に自動的にルールが構築されるようにした

## 動作確認 / Verification

- [x] Firefox系のブラウザでも問題なく動作するか
  - 検証したバージョン
    - Floorp (Firefox 151)

## その他の変更 / Other Changes
- なし

## マージ後の Open-Deck バージョン / Open-Deck version after merging
- `1.1.3.3`

## 雑記(あればご自由にどうぞ) / Personal Notes (Optional / Feel free to write anything!)
今回は目新しい機能はないですが、Open-Deck自体の安定性や使い勝手を改善させました！

特にポストカラムなどで文字の入力中にカラムの自動更新タイミングがやってきた場合に
文字入力ができなくなる問題などが発生していたため、修正しました！

少し前に、公式ドキュメントも作りました！
使い方やOpen-Deckについてもっと知りたい方はぜひ、見てください！

→ [公式ドキュメント](https://kawa-nobu.github.io/Open-Deck-Wiki/)


- 作業の時に聴いていた楽曲(覚えている限り)
  - 君だけの欠片 / エミリー スチュアート (CV: 郁原ゆう)
    - https://youtu.be/5d_ZKnOgLoI
  - 聞こえなくてもありがとう / ミルキィホームズ
    - https://youtu.be/fLZ3PqyAlgY
  - 東の空から始まる世界 / yuiko
    - https://youtu.be/qtr-JRvFOKE