### PR TITLE
fix: カラム内のタブ一覧の矢印ボタンが動作しない問題を修正

### DIFF
--- a/extensions/auto_reload_helper.js
+++ b/extensions/auto_reload_helper.js
@@ -3,17 +3,49 @@
     let path_old = null;
     let opd_reload_token = null;
     let reload_func = ()=>{};
+    let isFocusDisabled = false;
+    
+    // ユーザー操作でフォーカス無効化を解除する
+    ['mousedown', 'keydown', 'touchstart'].forEach(type => {
+        document.addEventListener(type, () => {
+            isFocusDisabled = false;
+        }, { capture: true, passive: true });
+    });
 
-    // 自動更新時にフォーカスされる問題があるので、scrollIntoViewとfocusを無効化する
+    // 自動更新時にフォーカスされる問題があるので、scrollIntoViewとfocusを一時的に無効化する
     const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
     HTMLElement.prototype.scrollIntoView = function(options) {
-        //上へのスクロールはOpen-Deck側で制御するので無効化する
-        return;
+        //フォーカス無効化が有効だった場合はフォーカスを無視する
+        if (isFocusDisabled) return;
+
+        // カラム側のスクロールが親の横スクロールにも伝搬する問題を以下で対処する
+        // 直近のスクロール可能な親要素を探す
+        let parent = this.parentElement;
+        while (parent && !/(auto|scroll)/.test(getComputedStyle(parent).overflow)) {
+            parent = parent.parentElement;
+        }
+        if (!parent) return;
+
+        // 対象要素とスクロール親の位置差分を取得してスクロールする
+        const client_rect = this.getBoundingClientRect();
+        const parent_client_rect = parent.getBoundingClientRect();
+
+        // はみ出し量を算出
+        const delta = (start, end, pStart, pEnd) =>
+            start < pStart ? start - pStart : end > pEnd ? end - pEnd : 0;
+
+        parent.scrollBy({
+            left: delta(client_rect.left, client_rect.right, parent_client_rect.left, parent_client_rect.right),
+            top: delta(client_rect.top, client_rect.bottom, parent_client_rect.top, parent_client_rect.bottom),
+            behavior: options?.behavior
+        });
     };
 
     const originalFocus = HTMLElement.prototype.focus;
     HTMLElement.prototype.focus = function(options) {
-        //自動更新が必要なカラム内ではフォーカスが不要なので無効化する
+        if (isFocusDisabled){
+            return;
+        }
         return originalFocus.call(this, Object.assign({}, options, { preventScroll: true }));
     };
 
@@ -60,6 +92,7 @@
         if(typeof reload_func !== 'function') return;
 
         try {
+            isFocusDisabled = true;
             reload_func();
         } catch (err) {
             console.warn('reload_func threw->', err);

--- a/extensions/auto_reload_helper.js
+++ b/extensions/auto_reload_helper.js
@@ -5,7 +5,7 @@
     let reload_func = ()=>{};
     let isFocusDisabled = false;
     
-    // ユーザー操作でフォーカス無効化を解除する
+    //ユーザー操作でフォーカス無効化を解除する
     ['mousedown', 'keydown', 'touchstart'].forEach(type => {
         document.addEventListener(type, () => {
             isFocusDisabled = false;
@@ -13,24 +13,23 @@
     });
 
     // 自動更新時にフォーカスされる問題があるので、scrollIntoViewとfocusを一時的に無効化する
-    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
     HTMLElement.prototype.scrollIntoView = function(options) {
         //フォーカス無効化が有効だった場合はフォーカスを無視する
         if (isFocusDisabled) return;
 
-        // カラム側のスクロールが親の横スクロールにも伝搬する問題を以下で対処する
-        // 直近のスクロール可能な親要素を探す
+        //カラム側のスクロールが親の横スクロールにも伝搬する問題を以下で対処する
+        //直近のスクロール可能な親要素を探す
         let parent = this.parentElement;
         while (parent && !/(auto|scroll)/.test(getComputedStyle(parent).overflow)) {
             parent = parent.parentElement;
         }
         if (!parent) return;
 
-        // 対象要素とスクロール親の位置差分を取得してスクロールする
+        //対象要素とスクロール親の位置差分を取得してスクロールする
         const client_rect = this.getBoundingClientRect();
         const parent_client_rect = parent.getBoundingClientRect();
 
-        // はみ出し量を算出
+        //はみ出し量を算出
         const delta = (start, end, pStart, pEnd) =>
             start < pStart ? start - pStart : end > pEnd ? end - pEnd : 0;
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Open-Deck",
-  "version": "1.1.3.5",
+  "version": "1.1.3.6",
   "manifest_version": 3,
   "description": "The OpenSource Deck",
   "default_locale": "ja",

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,6 +1,6 @@
 {
     "name": "Open-Deck",
-    "version": "1.1.3.5",
+    "version": "1.1.3.6",
     "manifest_version": 2,
     "description": "The OpenSource Deck",
     "default_locale": "ja",


### PR DESCRIPTION
## 追加されたもの / New features
なし

## 直したもの / Fixed items
- カラム内のタブ一覧で表示される矢印ボタンが動作しない問題を修正(以下の画像のような部分)

<img width="373" height="50" alt="Image" src="https://github.com/user-attachments/assets/eb26e39e-855a-4ecc-b728-07ef185597d8" />

## 関連Issue
- #28 

## 動作確認 / Verification
- [x] Firefox系のブラウザでも問題なく動作するか
  - 検証したバージョン
    - Floorp 12.14.2 (Firefox151)

## その他の変更 / Other Changes
なし

## マージ後の Open-Deck バージョン / Open-Deck version after merging
- 1.1.3.6

## 雑記(あればご自由にどうぞ) / Personal Notes (Optional / Feel free to write anything!)
怒涛の1日2回アップデート！！！！！

本アップデートでは、 カラム内のタブ一覧で表示される矢印ボタンが動作しない問題を修正しました！
